### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Then, use it in your `Gulpfile.js`:
 const { upload, clean } = require('gulp-s3-publish');
 const { S3 } = require('aws-sdk'); 
 
-const client = S3();
+const client = new S3();
 
 const uploadOpts = {
   bucket: 'my-s3-bucket',


### PR DESCRIPTION
AWS sdk requires that S3 object must be constructed with new operator